### PR TITLE
plugsin/connection/serial: try to return to terminal mode before closing

### DIFF
--- a/src/plugins/connection/serial/sambaconnectionserialhelper.cpp
+++ b/src/plugins/connection/serial/sambaconnectionserialhelper.cpp
@@ -244,6 +244,9 @@ void SambaConnectionSerialHelper::close()
 {
 	if (m_serial.isOpen())
 	{
+		// Try to switch to terminal (ASCII) mode
+		writeSerial(QString("T#"));
+
 		m_serial.close();
 		emit connectionClosed();
 	}


### PR DESCRIPTION
SAM-BA cannot be used multiple times (without restarting the
processor) because it assumes that monitor is in terminal
mode. However, it places and leaves the monitor in normal mode on
exit.

This commit enables consecutive usage of SAM-BA by placing the monitor
back into terminal mode when closing the serial connection.